### PR TITLE
Small refactor

### DIFF
--- a/xprintidle.c
+++ b/xprintidle.c
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: GPL-2.0-only
  *
- * This program prints the "idle time" of the user to stdout.  The "idle time"
+ * This program prints the "idle time" of the user to stdout. The "idle time"
  * is the number of milliseconds since input was received on any input device.
  * If unsuccessful, the program prints a message to stderr and exits with a
  * non-zero exit code.
@@ -19,7 +19,7 @@
  *
  * xprintidle is distributed in the hope that it will be useful, but WITHOUT ANY
  * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
- * A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License along with
  * xprintidle. If not, see <https://www.gnu.org/licenses/>.

--- a/xprintidle.c
+++ b/xprintidle.c
@@ -68,8 +68,7 @@ void print_version(void) {
  * On success 0 is returned.
  * On error -1 is returned.
  */
-int get_x_idletime(uint64_t *idle)
-{
+int get_x_idletime(uint64_t *idle) {
   XScreenSaverInfo *ssi;
   Display *dpy;
   int event_basep, error_basep, vendrel;
@@ -164,7 +163,7 @@ unsigned long workaroundCreepyXServer(Display *dpy, unsigned long idleTime) {
 
   DPMSGetTimeouts(dpy, &standby, &suspend, &off);
   DPMSInfo(dpy, &state, &onoff);
-  
+
   if (!onoff)
     return idleTime;
 

--- a/xprintidle.c
+++ b/xprintidle.c
@@ -58,7 +58,7 @@ void print_usage(char *name) {
           name);
 }
 
-void print_version() {
+void print_version(void) {
   fprintf(stdout, "xprintidle %s\n", XPRINTIDLE_VERSION);
 }
 


### PR DESCRIPTION
Small refactor for (hopefully) better readability.

- The function `workaroundCreepyXServer()` has less nested if-statements.
- The function `print_version()` has specified parameters, `void`.
- Two spaces in the first comment had their apparent leading space removed.
-  clang-format removed the line break for the opening bracket of the function `get_x_idletime()`, which conforms to the style of all other function definitions in the file.
