### PR TITLE
Human-Readable option

### DIFF
--- a/xprintidle.1
+++ b/xprintidle.1
@@ -33,7 +33,7 @@ it to stdout (in milliseconds).
 .B \-h ", " \-\^\-help
 Output a usage message and exit.
 .TP
-.B \-\^\-human-readable
+.B \-H ", " \-\^\-human-readable
 Output the idle time in a human-readable format.
 .TP
 .B \-v ", " \-\^\-version

--- a/xprintidle.1
+++ b/xprintidle.1
@@ -33,6 +33,9 @@ it to stdout (in milliseconds).
 .B \-h ", " \-\^\-help
 Output a usage message and exit.
 .TP
+.B \-\^\-human-readable
+Output the idle time in a human-readable format.
+.TP
 .B \-v ", " \-\^\-version
 Output the version number and exit.
 .

--- a/xprintidle.c
+++ b/xprintidle.c
@@ -158,7 +158,7 @@ int main(int argc, char *argv[]) {
     if (!strcmp(argv[1], "-v") || !strcmp(argv[1], "--version")) {
       print_version();
       return EXIT_SUCCESS;
-    } else if (strcmp(argv[1], "--human-readable")) {
+    } else if (strcmp(argv[1], "-H") && strcmp(argv[1], "--human-readable")) {
       print_usage(argv[0]);
       return EXIT_FAILURE;
     }

--- a/xprintidle.c
+++ b/xprintidle.c
@@ -121,7 +121,7 @@ void print_human_time(uint64_t time) {
   /* The C standard says that integer division round towards 0. */
 
   int convFacs[] = {24 * 60 * 60 * 1000, 60 * 60 * 1000, 60 * 1000, 1000, 1};
-  char *names[] = {"days", "hours", "minutes", "seconds", "milliseconds"};
+  char *names[] = {"day", "hour", "minute", "second", "millisecond"};
   size_t units = sizeof(convFacs) / sizeof(int);
 
   int firstPrint = 1;
@@ -136,13 +136,15 @@ void print_human_time(uint64_t time) {
     if (!firstPrint)
       printf(", ");
     printf("%d %s", unitMag, names[i]);
+    if (unitMag != 1)
+      printf("s");
 
     firstPrint = 0;
   }
 
   /* Smallest unit would be 0. */
   if (firstPrint)
-    printf("0 %s", names[units - 1]);
+    printf("0 %ss", names[units - 1]);
 
   printf("\n");
 }

--- a/xprintidle.c
+++ b/xprintidle.c
@@ -120,28 +120,29 @@ int get_x_idletime(uint64_t *idle) {
 void print_human_time(uint64_t time) {
   /* The C standard says that integer division round towards 0. */
 
-  int days = (int)(time / (24 * 60 * 60 * 1000));
-  time %= 24 * 60 * 60 * 1000;
-  if (days)
-    printf("%d days ", days);
+  int convFacs[] = {24 * 60 * 60 * 1000, 60 * 60 * 1000, 60 * 1000, 1000, 1};
+  char *names[] = {"days", "hours", "minutes", "seconds", "milliseconds"};
+  size_t units = sizeof(convFacs) / sizeof(int);
 
-  int hours = (int)(time / (60 * 60 * 1000));
-  time %= 60 * 60 * 1000;
-  if (hours)
-    printf("%d hours ", hours);
+  int firstPrint = 1;
+  size_t i;
+  for (i = 0; i < units; i++) {
+    int unitMag = time / convFacs[i];
+    time %= convFacs[i];
 
-  int mins = (int)(time / (60 * 1000));
-  time %= 60 * 1000;
-  if (mins)
-    printf("%d minutes ", mins);
+    if (!unitMag)
+      continue;
 
-  int secs = (int)(time / 1000);
-  time %= 1000;
-  if (secs)
-    printf("%d seconds ", secs);
+    if (!firstPrint)
+      printf(", ");
+    printf("%d %s", unitMag, names[i]);
 
-  int ms = (int)(time % 1000);
-  printf("%d milliseconds", ms);
+    firstPrint = 0;
+  }
+
+  /* Smallest unit would be 0. */
+  if (firstPrint)
+    printf("0 %s", names[units - 1]);
 
   printf("\n");
 }

--- a/xprintidle.c
+++ b/xprintidle.c
@@ -116,21 +116,60 @@ int get_x_idletime(uint64_t *idle) {
   return 0;
 }
 
+/* This function prints miliseconds in a human-readable format. */
+void print_human_time(uint64_t time) {
+  /* The C standard says that integer division round towards 0. */
+
+  int days = (int)(time / (24 * 60 * 60 * 1000));
+  time %= 24 * 60 * 60 * 1000;
+  if (days)
+    printf("%d days ", days);
+
+  int hours = (int)(time / (60 * 60 * 1000));
+  time %= 60 * 60 * 1000;
+  if (hours)
+    printf("%d hours ", hours);
+
+  int mins = (int)(time / (60 * 1000));
+  time %= 60 * 1000;
+  if (mins)
+    printf("%d minutes ", mins);
+
+  int secs = (int)(time / 1000);
+  time %= 1000;
+  if (secs)
+    printf("%d seconds ", secs);
+
+  int ms = (int)(time % 1000);
+  printf("%d milliseconds", ms);
+
+  printf("\n");
+}
+
 int main(int argc, char *argv[]) {
   uint64_t idle;
+  int human = 0;
 
   /* TODO change this to getopts as soon as we have more options */
   if (argc != 1) {
     if (!strcmp(argv[1], "-v") || !strcmp(argv[1], "--version")) {
       print_version();
       return EXIT_SUCCESS;
+    } else if (strcmp(argv[1], "--human-readable")) {
+      print_usage(argv[0]);
+      return EXIT_FAILURE;
     }
-    print_usage(argv[0]);
-    return EXIT_FAILURE;
+
+    human = 1;
   }
 
   if (get_x_idletime(&idle) < 0) {
     return EXIT_FAILURE;
+  }
+
+  if (human) {
+    print_human_time(idle);
+    return EXIT_SUCCESS;
   }
 
   printf("%lu\n", idle);


### PR DESCRIPTION
An option to output the idle time in a human-readable format, using the `--human-readable` option — the option `-h` was not used because it would conflict with the help option, according to the manual. Also, I do not know the .1 format, so I changed it in a way that looked right.

The human-readable format prints the time in human time units. Separates the units by comma, uses as many units as necessary and pluralize the nouns. For example, if the idle time were `61926 ms`, the output of `xprintidle --human-readable` would be 

`1 minute, 1 second, 926 milliseconds`.