### PR TITLE
Fix value overflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ meson install -C build
 
 ### Dependencies ###
 
-You need the development files for the X11, Xext and Xss library.
+You need the development files for the X11, Xext and Xss libraries, and a
+C99-compliant compiler.
 
 ## Contributing ##
 

--- a/meson.build
+++ b/meson.build
@@ -3,7 +3,7 @@ project('xprintidle',
   version : '0.2.5',
   license : 'GPL-2.0',
   default_options : [
-    'c_std=c89',
+    'c_std=c99',
     'warning_level=3',
     'optimization=3',
   ]

--- a/xprintidle.c
+++ b/xprintidle.c
@@ -177,7 +177,7 @@ int main(int argc, char *argv[]) {
     return EXIT_SUCCESS;
   }
 
-  printf("%lu\n", idle);
+  printf("%llu\n", idle);
   return EXIT_SUCCESS;
 }
 


### PR DESCRIPTION
On some platforms (e.g. armv7), printf overflows, causing the idle time to be printed as 8192. Fix by using a larger printf  specifier and bumping the C standard to C99, where the specifier is available.